### PR TITLE
Support just publike keys, without certificate wrapper

### DIFF
--- a/dumppublickey
+++ b/dumppublickey
@@ -21,7 +21,7 @@ import traceback
 from dumpkey import dumppublickey
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        sys.stderr.write("Usage: DumpPublicKey certfile ... > source.c")
+        sys.stderr.write("Usage: DumpPublicKey certfile ... > source.c\n")
         sys.exit(1)
     try:
         out = []


### PR DESCRIPTION
I needed to dump the public signing key used for LineageOS, which is provided at https://github.com/LineageOS/update_verifier/blob/da95704c7b0439882859e375aabe1c2a29a9ba26/lineageos_pubkey, in order to teach TWRP to trust it for zip signing, as part of an attempt to follow https://mjg59.dreamwidth.org/31765.html and make a locked bootloader work with LineageOS on my device.

I've modified the code to try loading the public key by itself if presented with a public key and not a whole certificate. It seems to work.

